### PR TITLE
Add JobCodec convenience methods

### DIFF
--- a/core/src/main/scala/com/itv/scheduler/JobCodec.scala
+++ b/core/src/main/scala/com/itv/scheduler/JobCodec.scala
@@ -1,3 +1,23 @@
 package com.itv.scheduler
 
+import cats.data.Chain
+import cats.{Contravariant, Functor, Invariant}
+
 trait JobCodec[A] extends JobDecoder[A] with JobDataEncoder[A]
+
+object JobCodec {
+  implicit val invariantInstance: Invariant[JobCodec] = new Invariant[JobCodec] {
+    override def imap[A, B](fa: JobCodec[A])(f: A => B)(g: B => A): JobCodec[B] =
+      JobCodec.from[B](Functor[JobDecoder].map(fa)(f), Contravariant[JobDataEncoder].contramap(fa)(g))
+  }
+
+  def from[A](implicit decodeA: JobDecoder[A], encodeA: JobDataEncoder[A]): JobCodec[A] = new JobCodec[A] {
+    override private[scheduler] def read(path: Chain[String], jobData: PartiallyDecodedJobData): Either[Throwable, A] =
+      decodeA.read(path, jobData)
+
+    override private[scheduler] def apply(a: A): Map[List[String], String] =
+      encodeA.apply(a)
+  }
+
+  def apply[A](implicit ev: JobCodec[A]): JobCodec[A] = ev
+}

--- a/core/src/main/scala/com/itv/scheduler/JobCodec.scala
+++ b/core/src/main/scala/com/itv/scheduler/JobCodec.scala
@@ -3,7 +3,10 @@ package com.itv.scheduler
 import cats.data.Chain
 import cats.{Contravariant, Functor, Invariant}
 
-trait JobCodec[A] extends JobDecoder[A] with JobDataEncoder[A]
+trait JobCodec[A] extends JobDecoder[A] with JobDataEncoder[A] {
+  def iemap[B](f: A => Either[Throwable, B])(g: B => A): JobCodec[B] =
+    JobCodec.from(emap(f), Contravariant[JobDataEncoder].contramap(this)(g))
+}
 
 object JobCodec {
   implicit val invariantInstance: Invariant[JobCodec] = new Invariant[JobCodec] {

--- a/core/src/main/scala/com/itv/scheduler/JobDecoder.scala
+++ b/core/src/main/scala/com/itv/scheduler/JobDecoder.scala
@@ -1,5 +1,6 @@
 package com.itv.scheduler
 
+import cats.Functor
 import cats.data.Chain
 import cats.syntax.all._
 import com.itv.scheduler.QuartzOps.JobDataMapOps
@@ -18,6 +19,12 @@ trait JobDecoder[A] { self =>
 }
 
 object JobDecoder {
+  implicit val functorInstance: Functor[JobDecoder] =
+    new Functor[JobDecoder] {
+      override def map[A, B](fa: JobDecoder[A])(f: A => B): JobDecoder[B] =
+        JobDecoder.instance[B](fa.read(_, _).map(f))
+    }
+
   def apply[A](implicit ev: JobDecoder[A]): JobDecoder[A] = ev
 
   def instance[A](read: (Chain[String], PartiallyDecodedJobData) => Either[Throwable, A]): JobDecoder[A] =


### PR DESCRIPTION
Add `Functor[JobDecoder]` instance as well.

Allows:
```scala
import cats.syntax.all.*
import com.itv.scheduler.JobCodec
import com.itv.scheduler.extruder.primitives.*

final case class ItvId(value: String)
object ItvId {
  implicit val jobCodec: JobCodec[ItvId] = JobCodec.from[String].imap(ItvId(_))(_.value)
}
```