### PR TITLE
Add job existance check

### DIFF
--- a/core/src/main/scala/com/itv/scheduler/QuartzTaskScheduler.scala
+++ b/core/src/main/scala/com/itv/scheduler/QuartzTaskScheduler.scala
@@ -24,6 +24,10 @@ trait TaskScheduler[F[_], J] {
     createJob(jobKey, job) *>
       scheduleTrigger(jobKey, triggerKey, jobTimeSchedule)
 
+  def checkExists(jobKey: JobKey): F[Boolean]
+
+  def checkExists(triggerKey: TriggerKey): F[Boolean]
+
   def createJob(jobKey: JobKey, job: J): F[Unit]
 
   def scheduleTrigger(jobKey: JobKey, triggerKey: TriggerKey, jobTimeSchedule: JobTimeSchedule): F[Option[Instant]]
@@ -39,6 +43,9 @@ class QuartzTaskScheduler[F[_], J](
     scheduler: Scheduler
 )(implicit F: Sync[F], jobDataEncoder: JobDataEncoder[J])
     extends TaskScheduler[F, J] {
+
+  override def checkExists(jobKey: JobKey): F[Boolean]         = F.blocking(scheduler.checkExists(jobKey))
+  override def checkExists(triggerKey: TriggerKey): F[Boolean] = F.blocking(scheduler.checkExists(triggerKey))
 
   override def createJob(jobKey: JobKey, job: J): F[Unit] =
     F.blocking {

--- a/core/src/test/scala/com/itv/scheduler/QuartzTaskSchedulerTest.scala
+++ b/core/src/test/scala/com/itv/scheduler/QuartzTaskSchedulerTest.scala
@@ -93,8 +93,8 @@ class QuartzTaskSchedulerTest extends AnyFlatSpec with Matchers with ForAllTestC
             JobScheduledAt(Instant.now().plusSeconds(2))
           )
 
-          exists      <- scheduler.checkExists(TriggerKey.triggerKey("sample-job"))
-          nonexistent <- scheduler.checkExists(TriggerKey.triggerKey("non-job"))
+          exists      <- scheduler.checkExists(TriggerKey.triggerKey("sample-trigger"))
+          nonexistent <- scheduler.checkExists(TriggerKey.triggerKey("non-trigger"))
 
         } yield {
           exists shouldBe true


### PR DESCRIPTION
Allow users to query the scheduler to see if a recurring job already exists, to prevent re-scheduling the same jobs.