### PR TITLE
Ability to specify additional props

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Quarts scheduler library using cats-effect queues for handling results.
 ### Import
 ```scala
 libraryDependencies ++= Seq(
-  "com.itv" %% "quartz4s-core"     % "1.0.2-SNAPSHOT",
+  "com.itv" %% "quartz4s-core"     % "1.0.4",
 )
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -50,6 +50,12 @@ val commonSettings: Seq[Setting[_]] = Seq(
         <organization>ITV</organization>
         <organizationUrl>http://www.itv.com</organizationUrl>
       </developer>
+      <developer>
+        <id>Angel-O</id>
+        <name>Angelo Oparah</name>
+        <organization>ITV</organization>
+        <organizationUrl>http://www.itv.com</organizationUrl>
+      </developer>
     </developers>,
   credentials ++= {
     sys.env

--- a/core/src/main/scala/com/itv/scheduler/Quartz4sConfig.scala
+++ b/core/src/main/scala/com/itv/scheduler/Quartz4sConfig.scala
@@ -42,7 +42,7 @@ final case class Quartz4sConfig(
     threadPool: ThreadPoolConfig,
     dataSource: DataSourceConfig,
 ) {
-  private[scheduler] def toPropertiesMap: Map[String, String] = {
+  private[scheduler] def defaultProperties: Map[String, String] = {
     val dataSourcePropPrefix = s"$PROP_DATASOURCE_PREFIX.${dataSource.dataSourceName}"
     Map(
       PROP_JOB_STORE_CLASS                          -> jobStore.jobStoreClass.getName,
@@ -59,10 +59,18 @@ final case class Quartz4sConfig(
     )
   }
 
+  /** sets the default scheduler properties */
   def toQuartzProperties: QuartzProperties = {
-    val propMap = toPropertiesMap
     val props   = new Properties()
-    propMap.foreach { case (k, v) => props.setProperty(k, v) }
+    defaultProperties.foreach { case (k, v) => props.setProperty(k, v) }
+    QuartzProperties(props)
+  }
+
+  /** sets the default scheduler properties allowing client code to specify additional properties.
+   * Note: additional properties will replace any existing property with a matching key */
+  def toQuartzProperties(additionalProperties: Map[String, String]): QuartzProperties = {
+    val props   = new Properties()
+    (defaultProperties ++ additionalProperties).foreach { case (k, v) => props.setProperty(k, v) }
     QuartzProperties(props)
   }
 }

--- a/core/src/main/scala/com/itv/scheduler/Quartz4sConfig.scala
+++ b/core/src/main/scala/com/itv/scheduler/Quartz4sConfig.scala
@@ -61,9 +61,13 @@ final case class Quartz4sConfig(
 
   /** sets the default scheduler properties */
   def toQuartzProperties: QuartzProperties = {
-    val props   = new Properties()
-    defaultProperties.foreach { case (k, v) => props.setProperty(k, v) }
-    QuartzProperties(props)
+    toQuartzProperties(Map.empty[String, String])
+  }
+
+  /** sets the default scheduler properties allowing client code to specify additional properties.
+   * Note: additional properties will replace any existing property with a matching key */
+  def toQuartzProperties(additionalProperties: (String, String)*): QuartzProperties = {
+    toQuartzProperties(additionalProperties.toMap)
   }
 
   /** sets the default scheduler properties allowing client code to specify additional properties.

--- a/core/src/test/scala/com/itv/scheduler/Quartz4sConfigTest.scala
+++ b/core/src/test/scala/com/itv/scheduler/Quartz4sConfigTest.scala
@@ -46,7 +46,7 @@ class Quartz4sConfigTest extends AnyFlatSpec with Matchers with ScalaCheckDriven
         "org.quartz.dataSource.ds.password"       -> password,
         "org.quartz.dataSource.ds.maxConnections" -> maxConnections.toString,
       )
-      quartzConfig.toPropertiesMap should contain theSameElementsAs expectedProperties
+      quartzConfig.defaultProperties should contain theSameElementsAs expectedProperties
     }
   }
 }

--- a/core/src/test/scala/com/itv/scheduler/Quartz4sConfigTest.scala
+++ b/core/src/test/scala/com/itv/scheduler/Quartz4sConfigTest.scala
@@ -49,4 +49,34 @@ class Quartz4sConfigTest extends AnyFlatSpec with Matchers with ScalaCheckDriven
       quartzConfig.defaultProperties should contain theSameElementsAs expectedProperties
     }
   }
+
+  it should "set additional properties overriding default props with a matching key" in {
+    forAll(
+      Gen.posNum[Int],
+      Gen.posNum[Int],
+      sizedStringGen,
+      sizedStringGen,
+      sizedStringGen,
+    ) { case (threadCount, maxConnections, jdbcUrl, username, password) =>
+      val quartzConfig = Quartz4sConfig(
+        JobStoreConfig(
+          driverDelegateClass = classOf[org.quartz.impl.jdbcjobstore.PostgreSQLDelegate],
+        ),
+        ThreadPoolConfig(threadCount),
+        DataSourceConfig(
+          driverClass = classOf[org.postgresql.Driver],
+          jdbcUrl = jdbcUrl,
+          username = username,
+          password = password,
+          maxConnections = maxConnections,
+        )
+      )
+
+      val additionalProperties: Map[String, String] = Map(
+        "org.quartz.jobStore.isClustered" -> "false"
+      )
+
+      quartzConfig.toQuartzProperties(additionalProperties).properties.get("org.quartz.jobStore.isClustered") should be ("false")
+    }
+  }
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.5-SNAPSHOT"
+version in ThisBuild := "1.0.6-SNAPSHOT"


### PR DESCRIPTION
### Summary

- ability to specify additional properties in code, for instance `org.quartz.scheduler.instanceName` useful to run multiple schedulers in the same app or `org.quartz.scheduler.threadName` to name the scheduler threads
- readme update to set the version to one available on Maven

See docs: http://www.quartz-scheduler.org/documentation/quartz-2.2.2/configuration/ConfigMain.html